### PR TITLE
feat: disable number validate in client side - emergency number support

### DIFF
--- a/src/modules/Phone/index.js
+++ b/src/modules/Phone/index.js
@@ -564,7 +564,7 @@ export function createPhone({
           appName: appNameForSDK,
           appVersion,
           webphoneLogLevel: 1,
-          // permissionCheck: false, // TODO: for Emmergency support in webRTC
+          permissionCheck: false,
         },
       },
       {
@@ -605,19 +605,18 @@ export function createPhone({
         },
         spread: true,
       },
-      // TODO: for Emmergency support in webRTC
-      // {
-      //   provide: 'CallOptions',
-      //   useValue: {
-      //     permissionCheck: false,
-      //   },
-      //   spread: true,
-      // },
+      {
+        provide: 'CallOptions',
+        useValue: {
+          permissionCheck: false,
+        },
+        spread: true,
+      },
       {
         provide: 'CallingSettingsOptions',
         useValue: {
           defaultCallWith,
-          // emergencyCallAvailable: true, // TODO: for Emmergency support in webRTC
+          emergencyCallAvailable: true,
         },
         spread: true,
       },


### PR DESCRIPTION
Disable number validate in client side. Number will be checked in server side.

Enable to E911 calling https://medium.com/ringcentral-developers/enabling-emergency-calls-for-ringcentral-webrtc-apps-ca2a69abcc2f
Support to pick a parked call https://github.com/ringcentral/ringcentral-embeddable-electron-app/issues/10