### PR TITLE
feat: throw error when app client id is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can use the config tool in this [page](https://ringcentral.github.io/ringcen
 
 #### Stable version
 
-We provide latest RingCentral Embeddable version on github page `https://ringcentral.github.io/ringcentral-embeddable`. It includes latest features and bugfix in RingCentral Embeddable. And it will keep up to date with master codes. But we **recommend** developers to use versioned RingCentral Embeddable. Current latest stable version of RingCentral Embeddable is `0.1.1`. You can get versioned app in this uri `https://apps.ringcentral.com/integration/ringcentral-embeddable/0.1.1`.
+We provide latest RingCentral Embeddable version on github page `https://ringcentral.github.io/ringcentral-embeddable`. It includes latest features and bugfix in RingCentral Embeddable. And it will keep up to date with master codes. But we **recommend** developers to use versioned RingCentral Embeddable. Current latest stable version of RingCentral Embeddable is `1.0.1`. You can get versioned app in this uri `https://apps.ringcentral.com/integration/ringcentral-embeddable/1.0.1`.
 
 Just replace `https://ringcentral.github.io/ringcentral-embeddable` in upper codes to the versioned uri, and you will be using versioned RingCentral Embeddable. The versioned app will not be influenced when new features are added, so it will be more stable than latest version. When you need to update RingCentral Embeddable, you need to update the versioned app uri in your codes manually.
 

--- a/docs/config-client-id-and-secret.md
+++ b/docs/config-client-id-and-secret.md
@@ -1,6 +1,6 @@
 # Using your own RingCentrall app client id and client secret
 
-Developer can config the Web Widget to use their own RingCentral app client id and client secret.
+Developer should config the Widget to use their own RingCentral app client id and client secret.
 
 1. Create a [RingCentral developer free account](https://developer.ringcentral.com)
 2. Create a RingCentral app with platform type - "Browser Based"
@@ -20,7 +20,7 @@ Developer can config the Web Widget to use their own RingCentral app client id a
 </script>
 ```
 
-`appSecret` is optional. If you provide `appSecret` to the Widget, it will use authorization code flow. If not, it will use implicit grant flow to log in.
+`appSecret` is optional. If you provide `appSecret` to the Widget, it will use authorization code flow. If not, it will use implicit grant flow to log in. In implicit flow, if user is inactive in 1 hour, login session will be expired. In authorization code flow, if user is inactive in 7 days, login session will be expired.
 
 ## Iframe way
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -49,4 +49,4 @@ Example scripts with versioned app:
 
 ## Important
 
-**Before going production, you should setup the Widget to use your own RingCentral app client id and client secrect in [here](config-client-id-and-secret.md). And use stable version Embeddable**
+**Before going to production, you should setup the widget to use your own RingCentral app client id and client secrect by following [here](config-client-id-and-secret.md). And use stable version Embeddable**

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -26,11 +26,9 @@ Create a iframe with the following codes:
 </iframe>
 ```
 
-You can also customize the Widget to use your RingCentral app client id and client secrect in [here](config-client-id-and-secret.md).
-
 #### Stable version
 
-We provide latest RingCentral Embeddable version on github page `https://ringcentral.github.io/ringcentral-embeddable`. It includes latest features and bugfix in RingCentral Embeddable. And it will keep up to date with master codes. But we **recommend** developers to use versioned RingCentral Embeddable. Current latest stable version of RingCentral Embeddable is `0.1.0`. You can get `0.1.0` app in this uri `https://apps.ringcentral.com/integration/ringcentral-embeddable/0.1.0`.
+We provide latest RingCentral Embeddable version on github page `https://ringcentral.github.io/ringcentral-embeddable`. It includes latest features and bugfix in RingCentral Embeddable. And it will keep up to date with master codes. But we **recommend** developers to use versioned RingCentral Embeddable. Current latest stable version of RingCentral Embeddable is `1.0.1`. You can get `1.0.1` app in this uri `https://apps.ringcentral.com/integration/ringcentral-embeddable/1.0.1`.
 
 Just replace `https://ringcentral.github.io/ringcentral-embeddable` in docs to the versioned uri, and you will be using versioned RingCentral Embeddable. The versioned app will not be influenced when new features are added, so it will be more stable than latest version. When you need to update RingCentral Embeddable, you need to update the versioned app uri in your codes manually.
 
@@ -48,3 +46,7 @@ Example scripts with versioned app:
   })();
 </script>
 ```
+
+#### Important
+
+**Before going production, you should setup the Widget to use your own RingCentral app client id and client secrect in [here](config-client-id-and-secret.md). And use stable version Embeddable**

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -47,6 +47,6 @@ Example scripts with versioned app:
 </script>
 ```
 
-#### Important
+## Important
 
 **Before going production, you should setup the Widget to use your own RingCentral app client id and client secrect in [here](config-client-id-and-secret.md). And use stable version Embeddable**

--- a/src/app.js
+++ b/src/app.js
@@ -24,7 +24,10 @@ if (apiConfig.appKey && apiConfig.appKey === defaultApiConfig.appKey) {
 }
 if (!apiConfig.appKey) {
   console.error('From v1.0.2, It is required to setup your own RingCentral Client Id. Please follow here to setup your own RingCentral app client id: https://github.com/ringcentral/ringcentral-embeddable/blob/master/docs/config-client-id-and-secret.md');
-  throw new Error('RingCentral App Client Id is required.');
+  // don't throw error in PR tests
+  if (window.location.hostname !== 'localhost') {
+    throw new Error('RingCentral App Client Id is required.');
+  }
 }
 
 const appVersion = pathParams.appVersion || process.env.APP_VERSION;

--- a/src/app.js
+++ b/src/app.js
@@ -19,6 +19,14 @@ const apiConfig = {
   server: pathParams.appServer || defaultApiConfig.server,
 };
 
+if (apiConfig.appKey && apiConfig.appKey === defaultApiConfig.appKey) {
+  console.warn('Default RingCentral client id is deprecated, it is required to setup your own RingCentral Client Id, Please stop using it soon before it is completely removed. Please follow here to setup your own RingCentral app client id: https://github.com/ringcentral/ringcentral-embeddable/blob/master/docs/config-client-id-and-secret.md');
+}
+if (!apiConfig.appKey) {
+  console.error('From v1.0.2, It is required to setup your own RingCentral Client Id. Please follow here to setup your own RingCentral app client id: https://github.com/ringcentral/ringcentral-embeddable/blob/master/docs/config-client-id-and-secret.md');
+  throw new Error('RingCentral App Client Id is required.');
+}
+
 const appVersion = pathParams.appVersion || process.env.APP_VERSION;
 
 const {


### PR DESCRIPTION
For #298, will remove default app Client id in  CDN versioned Embeddable from v1.0.2.

* show warning in master version
* throw error on CDN versioned Embeddable.