### PR TITLE
feat: show loading spinner on Save button while settings are saving

### DIFF
--- a/src/components/SettingSection/index.tsx
+++ b/src/components/SettingSection/index.tsx
@@ -58,6 +58,7 @@ export function SettingSection({
 }) {
   const [newSection, setNewSection] = useState(section);
   const [valueChanged, setValueChanged] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
     if (!section || !section.items) {
@@ -108,10 +109,16 @@ export function SettingSection({
           })
         }
         <StyledButton
-          onClick={() => {
-            onSave(newSection);
+          onClick={async () => {
+            setIsSaving(true);
+            try {
+              await onSave(newSection);
+            } finally {
+              setIsSaving(false);
+            }
           }}
-          disabled={!valueChanged || !allRequiredFilled(newSection.items)}
+          disabled={isSaving || !valueChanged || !allRequiredFilled(newSection.items)}
+          loading={isSaving}
         />
       </StyledPanel>
     </BackHeaderView>


### PR DESCRIPTION
The Save button on third-party setting section pages gave no feedback during the async save operation. Add an `isSaving` state that awaits the `onSave` promise, passes `loading` to SaveButton (already supported), and disables the button to prevent duplicate submissions.